### PR TITLE
Fix missing geopy import

### DIFF
--- a/components/google_places.py
+++ b/components/google_places.py
@@ -3,6 +3,7 @@ import googlemaps  # Note: LSP may not detect dynamic methods like places_nearby
 from typing import Dict, List, Tuple
 import time
 import logging
+import geopy.distance
 from utils.config_utils import is_test_mode_enabled, get_test_landmarks
 
 class GooglePlacesHandler:


### PR DESCRIPTION
## Summary
- fix missing geopy import in `GooglePlacesHandler`

## Testing
- `python tests/test_runner.py --test all`

------
https://chatgpt.com/codex/tasks/task_e_684729a1c714832a97ba8567fafe20fc